### PR TITLE
[FIX] Parsing of partition tables with wrong user_bin size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amebazii"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 repository = "https://github.com/MatrixEditor/amebazii"
 include = [
@@ -10,6 +10,7 @@ include = [
     "README.md",
     "examples/**/*"
 ]
+rust-version="1.81.0"
 
 [dependencies]
 byteorder = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AmebaZ2 / AmebaZII
 
-Open Source Implementation of OTA and Flash Generation for the AmebaZ2 SDK in Rust
+Open Source Implementation of OTA and Flash Generation for the AmebaZ2 SDK in Rust (**>=1.81.0**)
 
 > [!CAUTION]
 > This repository is an unofficial implementation based on reverse engineering of the official SDK and previous work from [ltchiptool](https://github.com/libretiny-eu/ltchiptool).

--- a/src/amebazii/error.rs
+++ b/src/amebazii/error.rs
@@ -1,6 +1,6 @@
 use hex::FromHexError;
 use openssl::error::ErrorStack;
-use std::io;
+use std::{error, io};
 
 #[derive(Debug)]
 pub enum Error {
@@ -13,6 +13,12 @@ pub enum Error {
     NotImplemented(String),
     InvalidState(String),
     SerdeJSONError(serde_json::Error),
+
+    // REVISIT: must be reworked
+    // individual parsing errors
+    MalformedKeyblock(String),
+    MalformedImageHeader(String),
+    MalfromedPartTab(String),
 }
 
 impl From<io::Error> for Error {


### PR DESCRIPTION
---

+ Added explicit minimum version in Cargo.toml
+ Partition table `user_len` will be capped at 256

Fixes #2 